### PR TITLE
use new version of rocketchat-lg-slash-commands

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -71,7 +71,7 @@ konecty:multiple-instances-status@1.0.6
 konecty:nrr@2.0.2
 konecty:user-presence@1.2.6
 launch-screen@1.0.4
-learnersguild:rocketchat-lg-slash-commands@0.3.4
+learnersguild:rocketchat-lg-slash-commands@0.3.5
 learnersguild:rocketchat-lg-sso@0.4.2
 less@2.5.1
 livedata@1.0.15

--- a/learners-guild/README.md
+++ b/learners-guild/README.md
@@ -91,8 +91,7 @@ The easiest way to test changes locally (that I've found so far) is to:
 
 2. Then, create a symbolic link from your clone of the git repository of the package into the `packages` directory:
 
-        $ cd packages
-        $ ln -s ../../rocketchat-lg-slash-commands .
+        $ ln -s ../../rocketchat-lg-slash-commands packages
 
 3. Then, re-add the package (it will check the `/packages` folder first):
 


### PR DESCRIPTION
Also fixing the README after running into a slight issue.

Don't merge until the [new version](https://github.com/LearnersGuild/rocketchat-lg-slash-commands/pull/18) of `rocketchat-lg-slash-commands` is live.
