### PR TITLE
auto join welcome and chapter channels on sign-up

### DIFF
--- a/packages/rocketchat-lg-core/common/util/getServiceBaseURL.js
+++ b/packages/rocketchat-lg-core/common/util/getServiceBaseURL.js
@@ -10,8 +10,13 @@ getServiceBaseURL = serviceName => {
   if (SERVICES.indexOf(serviceName) < 0) {
     throw new Error(`Invalid service name: ${serviceName}`)
   }
+
+  const context = typeof window !== 'undefined' ?
+    window.location.href :
+    process.env.ROOT_URL
+
   switch (true) {
-    case /\.dev/.test(window.location.href):
+    case /\.dev/.test(context):
       return `http://${serviceName}.learnersguild.dev`
     default:
       return `https://${serviceName}.learnersguild.org`

--- a/packages/rocketchat-lg-core/package.js
+++ b/packages/rocketchat-lg-core/package.js
@@ -17,12 +17,12 @@ Package.onUse(function (api) {
   ], {weak: true, unordered: false})
 
   api.addFiles([
-    'client/util/getServiceBaseURL.js',
     'client/mapEmoji.js',
     'client/sentry.js',
   ], 'client')
   api.addFiles([
     'common/util/getPackageLogger.js',
+    'common/util/getServiceBaseURL.js',
     'common/util/graphQLFetcher.js',
   ])
   api.addFiles([
@@ -33,12 +33,10 @@ Package.onUse(function (api) {
   api.export([
     'GAME',
     'IDM',
-    'getServiceBaseURL',
-  ], 'client')
-  api.export([
     'apiHeaders',
-    'graphQLFetcher',
     'getPackageLogger',
+    'getServiceBaseURL',
+    'graphQLFetcher',
     'rawGraphQLFetcher',
   ])
   api.export([

--- a/packages/rocketchat-lg-game/package.js
+++ b/packages/rocketchat-lg-game/package.js
@@ -39,6 +39,7 @@ Package.onUse(function (api) {
     'server/commands/index.js',
     'server/util/format.js',
     'server/util/notifyUser.js',
+    'server/afterCreateuser.js',
   ], 'server')
 })
 

--- a/packages/rocketchat-lg-game/server/afterCreateUser.js
+++ b/packages/rocketchat-lg-game/server/afterCreateUser.js
@@ -1,0 +1,69 @@
+/* global logger, getServiceBaseURL, graphQLFetcher, GAME */
+
+function getChapterChannelName(lgJWT, lgUser) {
+  const query = {
+    query: `
+query($id: ID!) {
+  getUserById(id: $id) {
+    chapter {
+      channelName
+    }
+  }
+}
+    `,
+    variables: {id: lgUser.id},
+  }
+
+  return graphQLFetcher(lgJWT, getServiceBaseURL(GAME))(query)
+    .then(data => data.getUserById)
+    .then(user => user.chapter.channelName)
+}
+
+function joinGameChannels(rcUser) {
+  const {lgJWT, lgUser} = rcUser.services.lgSSO
+  return getChapterChannelName(lgJWT, lgUser)
+    .then(chapterChannelName => {
+      Meteor.runAsUser(rcUser._id, () => {
+        ['welcome', chapterChannelName].forEach(channelName => {
+          logger.log(`${lgUser.handle} is joining ${channelName} ...`)
+          const room = RocketChat.models.Rooms.findOneByName(channelName)
+          Meteor.call('joinRoom', room._id)
+        })
+      })
+    })
+}
+
+function userIsInGame(lgUser) {
+  if (!lgUser || !lgUser.roles) {
+    return false
+  }
+  return lgUser.roles.indexOf('player') >= 0 || lgUser.roles.indexOf('moderator') >= 0
+}
+
+// for some reason, the passed-in user doesn't have an _id, so we need to
+// find the user by their username
+function afterCreateUser(options, {username}) {
+  try {
+    const rcUser = Meteor.users.findOne({username})
+    const {lgUser} = rcUser.services.lgSSO
+    if (userIsInGame(lgUser)) {
+      joinGameChannels(rcUser)
+        .catch(err => {
+          throw new Error(`unable to join game channels: ${err.message || err}`)
+        })
+    }
+  } catch (err) {
+    logger.error(err.stack || err)
+    RavenLogger.log(err)
+  }
+}
+
+/* eslint-disable prefer-arrow-callback */
+Meteor.startup(function () {
+  try {
+    RocketChat.callbacks.add('afterCreateUser', afterCreateUser)
+  } catch (err) {
+    logger.error(err.stack || err)
+    RavenLogger.log(err)
+  }
+})

--- a/packages/rocketchat-lg-sso/client/slidingSession.js
+++ b/packages/rocketchat-lg-sso/client/slidingSession.js
@@ -1,4 +1,4 @@
-/* global logger */
+/* global getServiceBaseURL, IDM, logger */
 
 let lastUserActivityAt = 0
 function updateLastUserActivityAt() {
@@ -33,8 +33,6 @@ function fetchJWTAndUpdateUserInfo() {
   }
 
   logger.log('fetching new JWT token and updating user info')
-  /* global window */
-  const baseURL = window.location.href.match(/learnersguild\.dev/) ? 'http://idm.learnersguild.dev' : 'https://idm.learnersguild.org'
   const {lgUser, lgJWT} = user.services.lgSSO
   const query = {
     query: `
@@ -49,7 +47,7 @@ query($id: ID!) {
 
   lastFetchAndUpdateAt = now
   /* global rawGraphQLFetcher */
-  return rawGraphQLFetcher(lgJWT, baseURL)(query)
+  return rawGraphQLFetcher(lgJWT, getServiceBaseURL(IDM))(query)
     .then(response => {
       const lgJWT = response.headers['learnersguild-jwt']
       if (lgJWT) {

--- a/packages/rocketchat-lg-sso/client/sso.js
+++ b/packages/rocketchat-lg-sso/client/sso.js
@@ -1,4 +1,4 @@
-/* global window, document, logger */
+/* global window, document, logger, getServiceBaseURL, IDM */
 
 function loginUsingLearnersGuildJWT(lgJWT, userCallback) {
   const methodArguments = [{lgSSO: true, lgJWT}]
@@ -35,10 +35,6 @@ function formatUrl(urlObject) {
   return url
 }
 
-function idmURL() {
-  return window.location.href.match(/learnersguild\.dev/) ? 'http://idm.learnersguild.dev' : 'https://idm.learnersguild.org'
-}
-
 // This is a weird hack. We'll wait until the loginLayout is created, and once
 // it has been created, we'll look for our token (which may have been passed
 // back to us from the IDM service if we're being redirected back because we
@@ -63,7 +59,7 @@ Template.loginLayout.created = function () {
   /* global HttpQueryString */
   const {inviteCode} = HttpQueryString.parse(window.location.search.slice(1))
   const authURLQuery = HttpQueryString.stringify({redirect, responseType: 'token'})
-  const authURL = inviteCode ? `${idmURL()}/sign-up/${inviteCode}?${authURLQuery}` : `${idmURL()}/sign-in?${authURLQuery}`
+  const authURL = inviteCode ? `${getServiceBaseURL(IDM)}/sign-up/${inviteCode}?${authURLQuery}` : `${getServiceBaseURL(IDM)}/sign-in?${authURLQuery}`
   logger.log(`no lgJWT token found in query string, redirecting to ${authURL}`)
   window.location.href = authURL
 }
@@ -71,7 +67,7 @@ Template.loginLayout.created = function () {
 Meteor.startup(() => {
   Accounts.onLoginFailure(() => {
     // if our login fails for any reason, we need to redirect to IDM with an auth error message
-    const failureRedirectURL = `${idmURL()}/sign-in?err=auth`
+    const failureRedirectURL = `${getServiceBaseURL(IDM)}/sign-in?err=auth`
     window.location.href = failureRedirectURL
   })
 })


### PR DESCRIPTION
## Review These First

Depends on https://github.com/LearnersGuild/game/pull/328
Based on refactor in https://github.com/LearnersGuild/echo-chat/pull/44

We will need to rebase from master once https://github.com/LearnersGuild/echo-chat/pull/44 is reviewed and feedback is integrated (and, of course, it gets merged).
## Fixes

Fixes #41.
Fixes #42.
Completes https://github.com/LearnersGuild/game/issues/284
## Overview

This PR adds a callback to Rocket.Chat for `afterCreateUser` (which is called whenever a new user is added to MongoDB). If the user created is a `player` or `moderator`, it will make a GraphQL request to `getUserById` on the `game` service (in order to get the name of the chapter channel), then it joins the 'welcome' and chapter channels.

This used to happen in `rocketchat-lg-sso`, but it doesn't belong there.
