### PR TITLE
handle GH username changes correctly

### DIFF
--- a/packages/rocketchat-lg-sso/server/sso.js
+++ b/packages/rocketchat-lg-sso/server/sso.js
@@ -46,6 +46,15 @@ function createOrUpdateUserFromJWT(lgJWT) {
     // don't kill any previous resume tokens when updating user info
     const services = Object.assign({}, rcUser.services, {lgSSO})
     const mergedUser = Object.assign({}, newUser, {services})
+
+    // Explicitly set username. It's a noop if the username is the same,
+    // bit it triggers all of the history re-writing necessary
+    // if the username really is changing.
+    Meteor.runAsUser(rcUser._id, () =>
+      Meteor.call('setUsername', lgUser.handle)
+    )
+
+    // Now update the rest of the user attributes
     Meteor.users.update(rcUser, mergedUser)
     rcUser = Meteor.users.findOne(rcUser._id)
   } else {


### PR DESCRIPTION
You need to call `setUsername` explicitly when the username is changing to trigger all of the cleanup and history re-writing that has to happen. It's smart enough to just bail early if the new username isn't different, so we can just call it every time we update user info from GH.

Fixes #59 
