### PR TITLE
	treat non-fatal avatar-setting error as a warning

### DIFF
--- a/packages/rocketchat-lg-sso/server/sso.js
+++ b/packages/rocketchat-lg-sso/server/sso.js
@@ -66,8 +66,7 @@ function createOrUpdateUserFromJWT(lgJWT) {
   try {
     setAvatarFromGitHubAvatar(rcUser, lgUser)
   } catch (err) {
-    RavenLogger.log(err)
-    logger.warn('could not set avatar from GitHub avatar', err.stack)
+    logger.warn('could not set avatar from GitHub avatar', err.message)
   }
 
   return rcUser


### PR DESCRIPTION
Fixes: #67 

## Overview

Part of the sign-in process for echo includes updating their avatar with whatever is on GitHub. However, if a user hasn't set-up an avatar on GitHub, a `404` will be returned by GitHub for their avatar.

Before this PR, we logged that error to Sentry, and dumped a stack trace. Since it's a non-fatal error, however, we now simply warn and don't log it to Sentry.