### PR TITLE
upgrade game-cli to version 1.2.1

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -71,7 +71,7 @@ konecty:user-presence@1.2.9
 launch-screen@1.1.0
 learnersguild:rocketchat-lg-api-extensions@1.0.1
 learnersguild:rocketchat-lg-core@1.0.1
-learnersguild:rocketchat-lg-game@1.1.2
+learnersguild:rocketchat-lg-game@1.1.3
 learnersguild:rocketchat-lg-sso@1.0.1
 less@2.7.8
 livedata@1.0.18

--- a/packages/rocketchat-lg-game/package.js
+++ b/packages/rocketchat-lg-game/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'learnersguild:rocketchat-lg-game',
-  version: '1.1.2',
+  version: '1.1.3',
   summary: 'Custom functionality for the Learners Guild game (including slash commands for Rocket.Chat).',
 })
 
@@ -45,6 +45,6 @@ Package.onUse(function (api) {
 })
 
 Npm.depends({
-  '@learnersguild/game-cli': '1.2.0',
+  '@learnersguild/game-cli': '1.2.1',
   'socketcluster-client': '4.3.17'
 })

--- a/packages/rocketchat-lg-sso/package.js
+++ b/packages/rocketchat-lg-sso/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'learnersguild:rocketchat-lg-sso',
-  version: '1.0.1',
+  version: '1.0.2',
   summary: 'Accounts login handler for Learners Guild SSO.',
 })
 


### PR DESCRIPTION
Fixes [ch478](https://app.clubhouse.io/learnersguild/story/478/bump-game-cli-version-in-rocketchat-lg-game-package-within-echo-chat).

## Overview

The `game-cli` and `game` repos were updated to support functionality described in [ch204](https://app.clubhouse.io/learnersguild/story/204/project-list-r-should-list-the-goal). This PR pulls-in the latest `game-cli` to roll that change out in echo.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

`game-cli` updated to version `1.2.1`.

## Notes

This _cannot_ be merged until [ch204](https://app.clubhouse.io/learnersguild/story/204/project-list-r-should-list-the-goal) is fully merged, deployed, and the updated `game-cli` is published to npm.