### PR TITLE
bump game-cli version and rocketchat package versions

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -71,8 +71,8 @@ konecty:user-presence@1.2.9
 launch-screen@1.1.0
 learnersguild:rocketchat-lg-api-extensions@1.0.1
 learnersguild:rocketchat-lg-core@1.0.1
-learnersguild:rocketchat-lg-game@1.1.3
-learnersguild:rocketchat-lg-sso@1.0.1
+learnersguild:rocketchat-lg-game@1.3.0
+learnersguild:rocketchat-lg-sso@1.0.2
 less@2.7.8
 livedata@1.0.18
 localstorage@1.0.12

--- a/packages/rocketchat-lg-game/package.js
+++ b/packages/rocketchat-lg-game/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'learnersguild:rocketchat-lg-game',
-  version: '1.1.3',
+  version: '1.3.0',
   summary: 'Custom functionality for the Learners Guild game (including slash commands for Rocket.Chat).',
 })
 
@@ -45,6 +45,6 @@ Package.onUse(function (api) {
 })
 
 Npm.depends({
-  '@learnersguild/game-cli': '1.2.1',
+  '@learnersguild/game-cli': '1.3.0',
   'socketcluster-client': '4.3.17'
 })


### PR DESCRIPTION
Partially addresses [ch101](https://app.clubhouse.io/learnersguild/story/101/players-have-timeontask-stat).

**DO NOT MERGE THIS** until the new `game-cli` npm module has been published, which depends on merging https://github.com/LearnersGuild/game-cli/pull/92 and https://github.com/LearnersGuild/game/pull/716

## Notes

- Related: https://github.com/LearnersGuild/game/pull/716
- Related: https://github.com/LearnersGuild/game-cli/pull/92